### PR TITLE
[af-46] refactor: entity 연관 관계 편의 메서드 추가

### DIFF
--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/category/entity/Category.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/category/entity/Category.java
@@ -1,6 +1,7 @@
 package com.drunkenlion.alcoholfriday.domain.category.entity;
 
 import com.drunkenlion.alcoholfriday.domain.item.entity.Item;
+import com.drunkenlion.alcoholfriday.domain.product.entity.Product;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +11,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Comment;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,5 +34,10 @@ public class Category extends BaseEntity {
     private String lastName;
 
     @OneToMany(mappedBy = "category")
-    private List<Item> items;
+    @Builder.Default
+    private List<Item> items = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category")
+    @Builder.Default
+    private List<Product> products = new ArrayList<>();
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/item/dao/ItemRepositoryCustom.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/item/dao/ItemRepositoryCustom.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ItemRepositoryCustom {
-    public Page<Item> search(List<String> keywordType, String keyword, Pageable pageable);
+    Page<Item> search(List<String> keywordType, String keyword, Pageable pageable);
+    Optional<Item> get(Long id);
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/item/dao/ItemRepositoryImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/item/dao/ItemRepositoryImpl.java
@@ -50,9 +50,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
         JPAQuery<Long> total = jpaQueryFactory
                 .select(item.count())
                 .from(item)
-                .leftJoin(itemProduct).on(itemProduct.item.id.eq(item.id)).fetchJoin()
-                .leftJoin(product).on(product.id.eq(itemProduct.product.id)).fetchJoin()
-                .leftJoin(category).on(category.id.eq(product.category.id)).fetchJoin()
+                .leftJoin(category).on(category.id.eq(item.category.id)).fetchJoin()
                 .where(builder);
 
         return PageableExecutionUtils.getPage(items, pageable, total::fetchOne);

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/Item.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/Item.java
@@ -4,10 +4,7 @@ import com.drunkenlion.alcoholfriday.domain.category.entity.Category;
 import com.drunkenlion.alcoholfriday.domain.order.entity.OrderDetail;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Comment;
 
@@ -17,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@ToString(callSuper = true)
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,8 +37,16 @@ public class Item extends BaseEntity {
     private Category category;
 
     @OneToMany(mappedBy = "item")
+    @Builder.Default
     private List<ItemProduct> itemProducts = new ArrayList<>();
 
     @OneToMany(mappedBy = "item")
+    @Builder.Default
     private List<OrderDetail> orderDetails = new ArrayList<>();
+
+    // 연관 관계 편의 메서드
+    public void addCategory(Category category) {
+        this.category = category;
+        category.getItems().add(this);
+    }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/ItemProduct.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/ItemProduct.java
@@ -21,4 +21,16 @@ public class ItemProduct extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", columnDefinition = "BIGINT", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     private Product product;
+
+    // 연관 관계 편의 메서드
+    public void addItem(Item item) {
+        this.item = item;
+        this.item.getItemProducts().add(this);
+    }
+
+    // 연관 관계 편의 메서드
+    public void addProduct(Product product) {
+        this.product = product;
+        this.product.getItemProducts().add(this);
+    }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/ItemProduct.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/item/entity/ItemProduct.java
@@ -3,14 +3,12 @@ package com.drunkenlion.alcoholfriday.domain.item.entity;
 import com.drunkenlion.alcoholfriday.domain.product.entity.Product;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
+@ToString(callSuper = true)
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/product/entity/Product.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/product/entity/Product.java
@@ -5,10 +5,7 @@ import com.drunkenlion.alcoholfriday.domain.item.entity.ItemProduct;
 import com.drunkenlion.alcoholfriday.domain.maker.entity.Maker;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Comment;
 
@@ -17,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@ToString(callSuper = true)
 @SuperBuilder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -75,5 +73,12 @@ public class Product extends BaseEntity {
     private Maker maker;
 
     @OneToMany(mappedBy = "product")
+    @Builder.Default
     private List<ItemProduct> itemProducts = new ArrayList<>();
+
+    // 연관 관계 편의 메서드
+    public void addCategory(Category category) {
+        this.category = category;
+        category.getProducts().add(this);
+    }
 }

--- a/src/test/java/com/drunkenlion/alcoholfriday/domain/item/api/ItemControllerTest.java
+++ b/src/test/java/com/drunkenlion/alcoholfriday/domain/item/api/ItemControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -43,6 +44,7 @@ class ItemControllerTest {
     private CategoryRepository categoryRepository;
 
     @BeforeEach
+    @Transactional
     void beforeEach() {
         Category category = Category.builder()
                 .firstName("식품")
@@ -87,6 +89,7 @@ class ItemControllerTest {
     }
 
     @AfterEach
+    @Transactional
     void afterEach() {
         itemProductRepository.deleteAll();
         itemRepository.deleteAll();


### PR DESCRIPTION
각 entity간 연관관계가 제대로 mapping되지않는 문제를 발견하였습니다.

이에 자주 사용하는 entity에 연관 관계 편의 메서드를 추가하여 이 문제를 해결하려고 했습니다.