### PR TITLE
[af-97] refactor: 회원 수정 시 중복된 닉네임에 대한 예외 처리

### DIFF
--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/auth/application/AuthServiceImpl.java
@@ -109,6 +109,8 @@ public class AuthServiceImpl implements AuthService {
     public OAuth2User loadUser(ProviderType provider, String accessToken) {
         SocialUserInfo userInfo = getSocialUserInfoFactory(provider, this.getAttributes(provider, accessToken));
 
+        log.info(this.getAttributes(provider, accessToken).toString());
+
         if (!StringUtils.hasText(userInfo.getEmail())) {
             throw new OAuth2AuthenticationException(String.format("%s 이메일을 찾을 수 없습니다.", provider.getProviderName()));
         }
@@ -131,27 +133,13 @@ public class AuthServiceImpl implements AuthService {
                     Member member = Member.builder()
                             .email(userInfo.getEmail())
                             .name(userInfo.getName())
-                            .nickname(checkNicknameDuplicate(userInfo.getNickname()))
+                            .nickname(userInfo.getNickname())
                             .role(MemberRole.MEMBER)
                             .provider(userInfo.getProvider())
                             .build();
 
                     return memberRepository.save(member);
                 });
-    }
-
-    private String checkNicknameDuplicate(String nickname) {
-        String newNickname = nickname;
-
-        if(memberRepository.existsByNickname(nickname)) {
-            newNickname = nickname + "_" + UUID.randomUUID();
-        }
-
-        if(newNickname.length() > 50) {
-            newNickname = newNickname.substring(0, 50);
-        }
-
-        return newNickname;
     }
 
     /**

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/auth/dto/KakaoUserInfo.java
@@ -30,8 +30,7 @@ public class KakaoUserInfo extends SocialUserInfo {
 
     @Override
     public String getNickname() {
-        return Optional.ofNullable((String) profile.get("nickname"))
-                .orElseGet(() -> getEmail().split("@")[0]);
+        return ProviderType.KAKAO + "_" + attributes.get("id");
     }
 
     @Override

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/member/application/MemberServiceImpl.java
@@ -1,6 +1,8 @@
 package com.drunkenlion.alcoholfriday.domain.member.application;
 
 import com.drunkenlion.alcoholfriday.domain.member.dto.MemberModifyRequest;
+import com.drunkenlion.alcoholfriday.global.common.response.HttpResponse;
+import com.drunkenlion.alcoholfriday.global.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,10 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     @Override
     public MemberResponse modifyMember(Member member, MemberModifyRequest modifyRequest) {
+        if (memberRepository.existsByNickname(modifyRequest.getNickname())) {
+            throw new BusinessException(HttpResponse.Fail.NICKNAME_IN_USE);
+        }
+
         member = member.toBuilder()
                 .nickname(modifyRequest.getNickname())
                 .phone(modifyRequest.getPhone())

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/common/response/HttpResponse.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/common/response/HttpResponse.java
@@ -58,6 +58,7 @@ public class HttpResponse {
         // 409
         CONFLICT(HttpStatus.CONFLICT, "이미 리소스가 존재합니다."),
         MAKER_IN_USE(HttpStatus.CONFLICT, "사용중인 제조사입니다."),
+        NICKNAME_IN_USE(HttpStatus.CONFLICT, "사용중인 닉네임입니다."),
 
         // 500 서버 에러
         INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다.");


### PR DESCRIPTION
1. 회원 수정 시 닉네임을 중복이 일어날 경우 예외가 발생하도록 수정했습니다.
2. 해당 예외에 맞는 메세지를 HttpResponse에 추가하였습니다.