### PR TITLE
[af-142] refactor: S3 내 이미지 저장 기능 리팩토링

### DIFF
--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/api/QuestionController.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/api/QuestionController.java
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
-@RequestMapping("/v1/cs/question")
-@Tag(name = "v1-question", description = "문의사항에 대한 API")
+@RequestMapping("/v1/questions")
+@Tag(name = "v1-question", description = "문의사항 API")
 @RestController
 public class QuestionController {
     private final QuestionService questionService;
 
-    @PostMapping("/save")
+    @PostMapping
     @Operation(summary = "문의사항 등록")
     public ResponseEntity<QuestionSaveResponse> saveQuestion(@RequestPart @Valid QuestionSaveRequest request,
                                                              @RequestPart List<MultipartFile> files,

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/application/QuestionServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/application/QuestionServiceImpl.java
@@ -5,7 +5,6 @@ import com.drunkenlion.alcoholfriday.domain.customerservice.dto.request.Question
 import com.drunkenlion.alcoholfriday.domain.customerservice.dto.response.QuestionSaveResponse;
 import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Question;
 import com.drunkenlion.alcoholfriday.domain.member.entity.Member;
-import com.drunkenlion.alcoholfriday.global.common.enumerated.EntityType;
 import com.drunkenlion.alcoholfriday.global.file.application.FileService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +24,8 @@ public class QuestionServiceImpl implements QuestionService {
     @Override
     @Transactional
     public QuestionSaveResponse saveQuestion(QuestionSaveRequest request, List<MultipartFile> files, Member member) {
-        Question question = QuestionSaveRequest.toEntity(request, member);
-        fileService.uploadFiles(files, question.getId(), EntityType.QUESTION);
-        return QuestionSaveResponse.of(questionRepository.save(question));
+        Question question = questionRepository.save(QuestionSaveRequest.toEntity(request, member));
+        fileService.saveFiles(question, files);
+        return QuestionSaveResponse.of(question);
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/application/QuestionServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/application/QuestionServiceImpl.java
@@ -6,6 +6,7 @@ import com.drunkenlion.alcoholfriday.domain.customerservice.dto.response.Questio
 import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Question;
 import com.drunkenlion.alcoholfriday.domain.member.entity.Member;
 import com.drunkenlion.alcoholfriday.global.file.application.FileService;
+import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class QuestionServiceImpl implements QuestionService {
     @Transactional
     public QuestionSaveResponse saveQuestion(QuestionSaveRequest request, List<MultipartFile> files, Member member) {
         Question question = questionRepository.save(QuestionSaveRequest.toEntity(request, member));
-        fileService.saveFiles(question, files);
-        return QuestionSaveResponse.of(question);
+        NcpFileResponse ncpFileResponse = fileService.saveFiles(question, files);
+        return QuestionSaveResponse.of(question, ncpFileResponse);
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/dto/response/QuestionSaveResponse.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/dto/response/QuestionSaveResponse.java
@@ -29,12 +29,25 @@ public class QuestionSaveResponse {
     @Schema(description = "문의사항 내용")
     private String content;
 
+    @Schema(description = "등록된 사진 정보")
+    private NcpFileResponse files;
+
     public static QuestionSaveResponse of(Question question) {
         return QuestionSaveResponse.builder()
                 .id(question.getId())
                 .member(question.getMember())
                 .title(question.getTitle())
                 .content(question.getContent())
+                .build();
+    }
+
+    public static QuestionSaveResponse of(Question question, NcpFileResponse files) {
+        return QuestionSaveResponse.builder()
+                .id(question.getId())
+                .member(question.getMember())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .files(files)
                 .build();
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/entity/Question.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/domain/customerservice/entity/Question.java
@@ -3,6 +3,7 @@ package com.drunkenlion.alcoholfriday.domain.customerservice.entity;
 import com.drunkenlion.alcoholfriday.domain.member.entity.Member;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
@@ -1,5 +1,6 @@
 package com.drunkenlion.alcoholfriday.global.common.enumerated;
 
+import com.amazonaws.services.kms.model.NotFoundException;
 import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Answer;
 import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Question;
 import com.drunkenlion.alcoholfriday.domain.item.entity.Item;
@@ -30,6 +31,6 @@ public enum EntityTypeV2 {
                 return entity.entityType;
             }
         }
-        throw new IllegalArgumentException("찾는 entity 정보가 존재하지 않습니다.");
+        throw new NotFoundException("Entity does not exist");
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
@@ -7,6 +7,8 @@ import com.drunkenlion.alcoholfriday.domain.item.entity.Item;
 import com.drunkenlion.alcoholfriday.domain.member.entity.Member;
 import com.drunkenlion.alcoholfriday.domain.product.entity.Product;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
+import com.drunkenlion.alcoholfriday.global.common.response.HttpResponse;
+import com.drunkenlion.alcoholfriday.global.exception.BusinessException;
 
 public enum EntityTypeV2 {
 
@@ -31,6 +33,6 @@ public enum EntityTypeV2 {
                 return entity.entityType;
             }
         }
-        throw new NotFoundException("Entity does not exist");
+        throw new BusinessException(HttpResponse.Fail.NOT_FOUND);
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/common/enumerated/EntityTypeV2.java
@@ -1,0 +1,35 @@
+package com.drunkenlion.alcoholfriday.global.common.enumerated;
+
+import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Answer;
+import com.drunkenlion.alcoholfriday.domain.customerservice.entity.Question;
+import com.drunkenlion.alcoholfriday.domain.item.entity.Item;
+import com.drunkenlion.alcoholfriday.domain.member.entity.Member;
+import com.drunkenlion.alcoholfriday.domain.product.entity.Product;
+import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
+
+public enum EntityTypeV2 {
+
+    QUESTION("question", Question.builder().build()),
+    ANSWER("answer", Answer.builder().build()),
+    ITEM("item", Item.builder().build()),
+    PRODUCT("product", Product.builder().build()),
+    MEMBER("member", Member.builder().build()),
+    ;
+
+    private final String entityType;
+    private final BaseEntity entityObj;
+
+    EntityTypeV2(String entityType, BaseEntity entityObj) {
+        this.entityType = entityType;
+        this.entityObj = entityObj;
+    }
+
+    public static String getEntityType(BaseEntity entityObj) {
+        for (EntityTypeV2 entity : EntityTypeV2.values()) {
+            if (entityObj.getClass().isInstance(entity.entityObj)) {
+                return entity.entityType;
+            }
+        }
+        throw new IllegalArgumentException("찾는 entity 정보가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
@@ -1,19 +1,21 @@
 package com.drunkenlion.alcoholfriday.global.file.application;
 
+import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import com.drunkenlion.alcoholfriday.global.common.enumerated.EntityType;
+import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
 import java.util.List;
-import java.util.Optional;
-
 import org.springframework.web.multipart.MultipartFile;
 
-import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
-
 public interface FileService {
+    NcpFileResponse saveFiles(BaseEntity entity, List<MultipartFile> multipartFiles);
+
     List<NcpFileResponse> findAllByEntityIds(List<Long> entityIds, String entityType);
 
     NcpFileResponse findByEntityId(Long entityId, String entityType);
+
     NcpFileResponse findByEntityId(Long entityId, EntityType entityType);
 
     NcpFileResponse uploadFiles(List<MultipartFile> multipartFiles, Long entityId, String EntityType);
+
     NcpFileResponse uploadFiles(List<MultipartFile> multipartFiles, Long entityId, EntityType entityType);
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
@@ -3,8 +3,6 @@ package com.drunkenlion.alcoholfriday.global.file.application;
 import com.amazonaws.services.kms.model.NotFoundException;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import com.drunkenlion.alcoholfriday.global.common.enumerated.EntityType;
-import com.drunkenlion.alcoholfriday.global.common.response.HttpResponse;
-import com.drunkenlion.alcoholfriday.global.exception.BusinessException;
 import com.drunkenlion.alcoholfriday.global.file.dao.FileRepository;
 import com.drunkenlion.alcoholfriday.global.ncp.application.NcpS3Service;
 import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
@@ -39,7 +37,7 @@ public class FileServiceImpl implements FileService {
             return null;
         }
 
-        NcpFile ncpFile = ncpS3Service.saveFilesToNCP(entity, multipartFiles);
+        NcpFile ncpFile = ncpS3Service.saveFiles(entity, multipartFiles);
         return NcpFileResponse.of(fileRepository.save(ncpFile));
     }
 

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
@@ -3,6 +3,8 @@ package com.drunkenlion.alcoholfriday.global.file.application;
 import com.amazonaws.services.kms.model.NotFoundException;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import com.drunkenlion.alcoholfriday.global.common.enumerated.EntityType;
+import com.drunkenlion.alcoholfriday.global.common.response.HttpResponse;
+import com.drunkenlion.alcoholfriday.global.exception.BusinessException;
 import com.drunkenlion.alcoholfriday.global.file.dao.FileRepository;
 import com.drunkenlion.alcoholfriday.global.ncp.application.NcpS3Service;
 import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
@@ -30,7 +32,7 @@ public class FileServiceImpl implements FileService {
     @Override
     public NcpFileResponse saveFiles(BaseEntity entity, List<MultipartFile> multipartFiles) {
         if (entity.getId() == null || entity.getId() == 0) {
-            throw new NotFoundException("Entity does not have an id");
+            throw new BusinessException(HttpResponse.Fail.NOT_FOUND);
         }
 
         if (multipartFiles.get(0).isEmpty()) { // MultipartFile 빈 값일 경우 배열의 0번째 값이 empty이다.

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImpl.java
@@ -1,5 +1,7 @@
 package com.drunkenlion.alcoholfriday.global.file.application;
 
+import com.amazonaws.services.kms.model.NotFoundException;
+import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import com.drunkenlion.alcoholfriday.global.common.enumerated.EntityType;
 import com.drunkenlion.alcoholfriday.global.common.response.HttpResponse;
 import com.drunkenlion.alcoholfriday.global.exception.BusinessException;
@@ -7,13 +9,14 @@ import com.drunkenlion.alcoholfriday.global.file.dao.FileRepository;
 import com.drunkenlion.alcoholfriday.global.ncp.application.NcpS3Service;
 import com.drunkenlion.alcoholfriday.global.ncp.dto.NcpFileResponse;
 import com.drunkenlion.alcoholfriday.global.ncp.entity.NcpFile;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -22,19 +25,56 @@ public class FileServiceImpl implements FileService {
     private final FileRepository fileRepository;
 
     /**
-     * 여러개의 게시물에 있는 모든 이미지 조회
+     * new 파일 저장 (Ncp & DB)
+     * Entity 데이터 save 후 id 값이 발급된 이후 저장 필요
+     * 반환 객체에 대해 null 체크 필요
+     */
+    @Override
+    public NcpFileResponse saveFiles(BaseEntity entity, List<MultipartFile> multipartFiles) {
+        if (entity.getId() == null || entity.getId() == 0) {
+            throw new NotFoundException("Entity does not have an id");
+        }
+
+        if (multipartFiles.get(0).isEmpty()) { // MultipartFile 빈 값일 경우 배열의 0번째 값이 empty이다.
+            return null;
+        }
+
+        NcpFile ncpFile = ncpS3Service.saveFilesToNCP(entity, multipartFiles);
+        return NcpFileResponse.of(fileRepository.save(ncpFile));
+    }
+
+    /**
+     * old 여러개의 게시물에 있는 모든 이미지 조회
      */
     @Override
     public List<NcpFileResponse> findAllByEntityIds(List<Long> entityIds, String entityType) {
-        List<NcpFile> ncpFiles = this.fileRepository.findAllByEntityIdInAndEntityType(entityIds, entityType);
-
+        List<NcpFile> ncpFiles =
+                fileRepository.findAllByEntityIdInAndEntityType(entityIds, entityType);
         return NcpFileResponse.of(ncpFiles);
     }
 
     /**
-     * EntityType 매개변수로 받는 메서드를 이용해주세요.
-     * 2차 개발일정 시작 시 해당 메서드는 삭제 예정입니다.
-     * 하나의 게시물에 있는 모든 이미지 조회
+     * old 하나의 게시물에 있는 모든 이미지 조회
+     */
+    @Override
+    public NcpFileResponse findByEntityId(Long entityId, EntityType entityType) {
+        NcpFile ncpFile =
+                fileRepository.findByEntityIdAndEntityType(entityId, entityType.getEntityName()).orElse(null);
+        return NcpFileResponse.of(ncpFile);
+    }
+
+    /**
+     * old 파일 저장 (Ncp & DB)
+     */
+    @Transactional
+    @Override
+    public NcpFileResponse uploadFiles(List<MultipartFile> multipartFiles, Long entityId, EntityType entityType) {
+        NcpFile ncpFile = ncpS3Service.ncpUploadFiles(multipartFiles, entityId, entityType.getEntityName());
+        return NcpFileResponse.of(fileRepository.save(ncpFile));
+    }
+
+    /**
+     * EntityType 매개변수로 받는 메서드를 이용해주세요. 2차 개발일정 시작 시 해당 메서드는 삭제 예정입니다. 하나의 게시물에 있는 모든 이미지 조회
      */
     @Deprecated
     @Override
@@ -45,35 +85,13 @@ public class FileServiceImpl implements FileService {
     }
 
     /**
-     * 하나의 게시물에 있는 모든 이미지 조회
-     */
-    @Override
-    public NcpFileResponse findByEntityId(Long entityId, EntityType entityType) {
-        NcpFile ncpFile = this.fileRepository.findByEntityIdAndEntityType(entityId, entityType.getEntityName())
-                .orElse(null);
-        return NcpFileResponse.of(ncpFile);
-    }
-
-    /**
-     * EntityType 매개변수로 받는 메서드를 이용해주세요.
-     * 2차 개발일정 시작 시 해당 메서드는 삭제 예정입니다.
-     * 파일 저장 (Ncp & DB)
+     * EntityType 매개변수로 받는 메서드를 이용해주세요. 2차 개발일정 시작 시 해당 메서드는 삭제 예정입니다. 파일 저장 (Ncp & DB)
      */
     @Deprecated
     @Transactional
     @Override
     public NcpFileResponse uploadFiles(List<MultipartFile> multipartFiles, Long entityId, String entityType) {
         NcpFile ncpFile = ncpS3Service.ncpUploadFiles(multipartFiles, entityId, entityType);
-        return NcpFileResponse.of(fileRepository.save(ncpFile));
-    }
-
-    /**
-     * 파일 저장 (Ncp & DB)
-     */
-    @Transactional
-    @Override
-    public NcpFileResponse uploadFiles(List<MultipartFile> multipartFiles, Long entityId, EntityType entityType) {
-        NcpFile ncpFile = ncpS3Service.ncpUploadFiles(multipartFiles, entityId, entityType.getEntityName());
         return NcpFileResponse.of(fileRepository.save(ncpFile));
     }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
@@ -1,12 +1,13 @@
 package com.drunkenlion.alcoholfriday.global.ncp.application;
 
+import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
+import com.drunkenlion.alcoholfriday.global.ncp.entity.NcpFile;
 import java.util.List;
-
 import org.springframework.web.multipart.MultipartFile;
 
-import com.drunkenlion.alcoholfriday.global.ncp.entity.NcpFile;
-
 public interface NcpS3Service {
+    NcpFile saveFilesToNCP(BaseEntity entity, List<MultipartFile> files);
+
     NcpFile ncpUploadFiles(List<MultipartFile> multipartFiles, Long entityId, String entityType);
 
     void ncpDeleteFile(String keyName);

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface NcpS3Service {
-    NcpFile saveFilesToNCP(BaseEntity entity, List<MultipartFile> files);
+    NcpFile saveFiles(BaseEntity entity, List<MultipartFile> files);
 
     NcpFile ncpUploadFiles(List<MultipartFile> multipartFiles, Long entityId, String entityType);
 

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3ServiceImpl.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3ServiceImpl.java
@@ -34,7 +34,7 @@ public class NcpS3ServiceImpl implements NcpS3Service {
      * NCP S3 bucket save
      */
     @Override
-    public NcpFile saveFilesToNCP(BaseEntity entity, List<MultipartFile> files) {
+    public NcpFile saveFiles(BaseEntity entity, List<MultipartFile> files) {
         int seq = 1;
         List<Map<String, Object>> fileMaps = new ArrayList<>();
         String entityType = EntityTypeV2.getEntityType(entity);


### PR DESCRIPTION
## 이미지 save 기능 추가
- 기존 코드는 에러 방지를 위하여 @Deprecated 어노테이션 추가 (2024.03.01 삭제예정)
- 신규 save method는 사용 편의성 증대를 위해 파라미터 간소화
- 이미지 s3 저장 시 파일명 내 seq 값 제거
  - 사유
    - 기존 로직에서 이미지 수정이 발생 시 seq 값이 재정렬 되어 db에 새롭게 저장이 되나 버킷에서는 seq가 수정되지 않는 점을 고려하여 파일명 내에서 seq 값 제거
    - NCP object storage에서는 직접적인 파일명 수정을 지원하지 않아 이미지 삭제 후 다시 저장을 해야하는 문제가 발생됨
## Question 이미지 저장 메서드 수정
## QuestionController 매핑 주소 수정
