### PR TITLE
[af-120] feat: 이미지 기능 구현

### DIFF
--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
@@ -8,7 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
     NcpFileResponse saveFiles(BaseEntity entity, List<MultipartFile> multipartFiles);
-
+    NcpFileResponse findAll(BaseEntity entity);
+    NcpFileResponse findOne(BaseEntity entity);
     List<NcpFileResponse> findAllByEntityIds(List<Long> entityIds, String entityType);
 
     NcpFileResponse findByEntityId(Long entityId, String entityType);

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/file/application/FileService.java
@@ -8,8 +8,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
     NcpFileResponse saveFiles(BaseEntity entity, List<MultipartFile> multipartFiles);
+
     NcpFileResponse findAll(BaseEntity entity);
+
     NcpFileResponse findOne(BaseEntity entity);
+
+    NcpFileResponse updateFiles(BaseEntity entity, List<Integer> removeSeq, List<MultipartFile> multipartFiles);
+
     List<NcpFileResponse> findAllByEntityIds(List<Long> entityIds, String entityType);
 
     NcpFileResponse findByEntityId(Long entityId, String entityType);

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/application/NcpS3Service.java
@@ -3,10 +3,13 @@ package com.drunkenlion.alcoholfriday.global.ncp.application;
 import com.drunkenlion.alcoholfriday.global.common.entity.BaseEntity;
 import com.drunkenlion.alcoholfriday.global.ncp.entity.NcpFile;
 import java.util.List;
+import java.util.Map;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface NcpS3Service {
     NcpFile saveFiles(BaseEntity entity, List<MultipartFile> files);
+
+    Map<String, Object> updateFile(BaseEntity entity, int seq, MultipartFile file);
 
     NcpFile ncpUploadFiles(List<MultipartFile> multipartFiles, Long entityId, String entityType);
 

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/dto/NcpFileResponse.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/dto/NcpFileResponse.java
@@ -40,9 +40,9 @@ public class NcpFileResponse {
         if (ncpFile != null && ncpFile.getS3Files() != null) {
             files = ncpFile.getS3Files().stream()
                     .map(json -> FileInfo.builder()
+                            .seq((Integer) json.get("seq"))
                             .keyName((String) json.get("keyName"))
                             .path((String) json.get("path"))
-                            .seq((Integer) json.get("seq"))
                             .build()
                     ).toList();
         }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/dto/NcpFileResponse.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/dto/NcpFileResponse.java
@@ -3,9 +3,13 @@ package com.drunkenlion.alcoholfriday.global.ncp.dto;
 import com.drunkenlion.alcoholfriday.global.ncp.entity.NcpFile;
 import com.drunkenlion.alcoholfriday.global.ncp.util.vo.FileInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
@@ -36,7 +40,7 @@ public class NcpFileResponse {
         if (ncpFile != null && ncpFile.getS3Files() != null) {
             files = ncpFile.getS3Files().stream()
                     .map(json -> FileInfo.builder()
-                            .keyName((String) json.get("key_name"))
+                            .keyName((String) json.get("keyName"))
                             .path((String) json.get("path"))
                             .seq((Integer) json.get("seq"))
                             .build()

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/entity/NcpFile.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/entity/NcpFile.java
@@ -34,4 +34,8 @@ public class NcpFile extends BaseEntity {
     @Column(name = "entity_type", columnDefinition = "VARCHAR(20)")
     @Comment("파일이 저장되는 entity 이름")
     private String entityType;
+
+    public void updateFiles(List<Map<String, Object>> files) {
+        this.s3Files = files;
+    }
 }

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/util/vo/FileInfo.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/util/vo/FileInfo.java
@@ -12,7 +12,7 @@ import lombok.*;
 public class FileInfo {
     @Schema(description = "file의 순번")
     private Integer seq;
-    
+
     @Schema(description = "file의 keyName")
     private String keyName;
 

--- a/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/util/vo/FileInfo.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/ncp/util/vo/FileInfo.java
@@ -10,12 +10,12 @@ import lombok.*;
 @ToString(callSuper = true)
 @Schema(description = "file 객체")
 public class FileInfo {
+    @Schema(description = "file의 순번")
+    private Integer seq;
+    
     @Schema(description = "file의 keyName")
     private String keyName;
 
     @Schema(description = "file의 full path")
     private String path;
-
-    @Schema(description = "file의 순번")
-    private Integer seq;
 }

--- a/src/test/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImplTest.java
+++ b/src/test/java/com/drunkenlion/alcoholfriday/global/file/application/FileServiceImplTest.java
@@ -33,7 +33,7 @@ class FileServiceImplTest {
     private NcpS3ServiceImpl ncpS3Service;
 
     // test를 위한 임의 변수
-    private final String key_name = "test";
+    private final String keyName = "test";
     private final String path = "src/test/java/com/drunkenlion/alcoholfriday/test.jpg";
     private final List<Long> entityIds = List.of(1L, 2L, 3L);
 
@@ -49,7 +49,7 @@ class FileServiceImplTest {
         for (NcpFileResponse fileResponse : files) {
             assertThat(fileResponse.getFile()).isNotNull();
             assertThat(fileResponse.getFile()).isInstanceOf(List.class);
-            assertThat(fileResponse.getFile().get(0).getKeyName()).isEqualTo(key_name);
+            assertThat(fileResponse.getFile().get(0).getKeyName()).isEqualTo(keyName);
             assertThat(fileResponse.getFile().get(0).getPath()).isEqualTo(path);
             assertThat(fileResponse.getFile().get(0).getSeq()).isEqualTo(1L);
         }
@@ -78,7 +78,7 @@ class FileServiceImplTest {
         // when
         NcpFileResponse ncpFileResponse = this.fileService.findByEntityId(entityIds.get(0), EntityType.ITEM.getEntityName());
         // then
-        assertThat(ncpFileResponse.getFile().get(0).getKeyName()).isEqualTo(key_name);
+        assertThat(ncpFileResponse.getFile().get(0).getKeyName()).isEqualTo(keyName);
         assertThat(ncpFileResponse.getFile().get(0).getPath()).isEqualTo(path);
         assertThat(ncpFileResponse.getFile().get(0).getSeq()).isEqualTo(1L);
     }
@@ -125,7 +125,7 @@ class FileServiceImplTest {
 
         for (int seq = 1; seq < 3; seq++) {
             Map<String, Object> map = new HashMap<>();
-            map.put("key_name", key_name);
+            map.put("keyName", keyName);
             map.put("path", path);
             map.put("seq", seq);
             s3Files.add(map);


### PR DESCRIPTION
# noti
- 개발 편의성 증대
  - 매개변수 수를 줄였습니다.
  - 기능 사용 시 null, empty 처리를 하지 않도록 기능 내부에서 처리하였습니다.

- 기능 개선
  - 범용적인 기능으로 multi thread 환경에서의 thread safe 하도록 리팩토링 하였습니다.
  - 주관적인 의견이지만 프론트엔드에 데이터를 넘길 때 json 데이터의 순서가 보기 편하도록 seq, keyName, path 순으로 보여지도록 수정하였습니다.

- 기존 메서드 @Deprecated
  - 기존 메서드를 사용하고 있는 코드의 error 방지를 위해 신규로 메서드를 작성하였습니다. 기존 메서드는 3월 1일자로 삭제 예정이므로 개발자분들은 수정하여 사용해 주시기 바랍니다.

<br>

## 이미지 저장
method : `saveFiles`
param : `BaseEntity entity, List<MultipartFile> files`
return : `NcpFileResponse`
method noti : 
- File 저장을 하는 기능은 다방면에서 사용되는 기능으로 seq 값을 thread safe한 AtomicInteger를 사용하였습니다.
- S3에 저장되는 file의 name에서 seq 제거

## 이미지 조회
method : `findAll`
return : `NcpFileResponse`
method noti : 
- entity가 보유한 모든 이미지가 포함된 NcpFileResponse를 반환합니다.

method : `findOne`
return : `NcpFileResponse`
method noti : 
- entity가 보유한 이미지 중 첫번째 이미지만 포함한 NcpFileResponse를 반환합니다.

## 이미지 수정
method : `updateFiles`
param : `param : BaseEntity entity, List<Integer> removeSeq, List<MultipartFile> multipartFiles`
return : `NcpFileResponse`
method noti : 
- 삭제할 seq를 가지고 있는 List와 추가할 이미지를 통해 기능이 작동합니다. 개발자들의 편의를 위해 기능 내부에서 null, empty 확인을 진행하므로 개발자들은 기능 사용 시 프론트로 부터 받은 데이터를 그대로 넘겨주시면 됩니다.

<br>

## 사용 예시
### Controller
```java
@GetMapping("{id}")
public ResponseEntity<QuestionResponse> get(@PathVariable("id") Long id) {
    QuestionResponse one = questionService.findOne(id);
    return ResponseEntity.ok(one);
}

@PutMapping("{id}")
public ResponseEntity<QuestionResponse> update(@PathVariable("id") Long id,
                   @RequestPart QuestionModifyRequest request,
                   @RequestPart List<MultipartFile> files) {

    QuestionResponse questionResponse = questionService.updateQuestion(id, request.getRemove(), files);
    return ResponseEntity.ok(questionResponse);
}
```


### Service
```java
@Override
public QuestionResponse findOne(Long id) {
    Question question = questionRepository.findById(id).get();
    NcpFileResponse all = fileService.findAll(question);
    return QuestionResponse.of(question, all);
}

@Override
@Transactional
public QuestionResponse updateQuestion(Long id, List<Integer> remove, List<MultipartFile> files) {
    Question question = questionRepository.findById(id).get();
    NcpFileResponse file = fileService.updateFiles(question, remove, files);
    return QuestionResponse.of(question, file);
}
```