### PR TITLE
[af-293] fix: Swagger 403 에러

### DIFF
--- a/src/main/java/com/drunkenlion/alcoholfriday/global/config/WebMvcConfig.java
+++ b/src/main/java/com/drunkenlion/alcoholfriday/global/config/WebMvcConfig.java
@@ -12,7 +12,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/v1/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:8080")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://localhost:8080",
+                        "https://api.alcoholfriday.shop",
+                        "https://api.alcoholfriday.store"
+                )
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
배포 도메인으로 Swagger 접속 후 Post 요청 시 403 에러가 발생하여 찾아본 결과,
cors 문제일 수 있다는 글을 참고하여 배포 도메인을 cors 설정에 추가하였습니다.