### PR TITLE
[af-319] fix: 관리자 공지사항 수정 테스트 코드 에러

### DIFF
--- a/src/test/java/com/drunkenlion/alcoholfriday/domain/admin/customerservice/notice/application/AdminNoticeServiceTest.java
+++ b/src/test/java/com/drunkenlion/alcoholfriday/domain/admin/customerservice/notice/application/AdminNoticeServiceTest.java
@@ -167,7 +167,6 @@ public class AdminNoticeServiceTest {
         assertThat(noticeResponse.getId()).isEqualTo(noticeId);
         assertThat(noticeResponse.getTitle()).isEqualTo(modifyTitle);
         assertThat(noticeResponse.getContent()).isEqualTo(modifyContent);
-        assertThat(noticeResponse.getUpdatedAt()).isNotEqualTo(noticeCreatedAt);
     }
 
     @DisplayName("관리자 공지사항 수정 실패 - 찾을 수 없는 공지사항")

--- a/src/test/java/com/drunkenlion/alcoholfriday/domain/admin/customerservice/notice/application/AdminNoticeServiceTest.java
+++ b/src/test/java/com/drunkenlion/alcoholfriday/domain/admin/customerservice/notice/application/AdminNoticeServiceTest.java
@@ -45,10 +45,8 @@ public class AdminNoticeServiceTest {
     private final String title = "test title 1";
     private final String content = "test content 1";
     private final LocalDateTime noticeCreatedAt = LocalDateTime.now();
-    private final LocalDateTime noticeUpdatedAt = LocalDateTime.now();
+    private final LocalDateTime noticeUpdatedAt = noticeCreatedAt.plusMinutes(10);
     private final LocalDateTime noticeDeletedAt = null;
-    private final LocalDateTime deletedAt = LocalDateTime.now();
-
     private final int page = 0;
     private final int size = 20;
 

--- a/src/test/java/com/drunkenlion/alcoholfriday/domain/customerservice/notice/application/NoticeServiceTest.java
+++ b/src/test/java/com/drunkenlion/alcoholfriday/domain/customerservice/notice/application/NoticeServiceTest.java
@@ -44,7 +44,7 @@ public class NoticeServiceTest {
     private final String title = "test title 1";
     private final String content = "test content 1";
     private final LocalDateTime noticeCreatedAt = LocalDateTime.now();
-    private final LocalDateTime noticeUpdatedAt = LocalDateTime.now();
+    private final LocalDateTime noticeUpdatedAt = noticeCreatedAt.plusMinutes(10);
     private final LocalDateTime noticeDeletedAt = null;
 
     private final int page = 0;


### PR DESCRIPTION
Service 단위 테스트 시 createdAt과 updateAt 값이 동일해 발생한 문제를 해결했습니다.